### PR TITLE
Add SQLite mirror with Postgres sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ We need to instanciate the DataBase and then attach the Model into it.
 ```python
 from autodla.dbs import PostgresDB, MemoryDB
 
-# Use PostgresDB() or the in-memory MemoryDB() depending on your setup
+# Use MemoryDB() for pure in-memory work. PostgresDB maintains a local
+# SQLite store and syncs it to PostgreSQL in the background.
 db = MemoryDB()
 db.attach([User])
 ```

--- a/autodla/dbs/postgresdb.py
+++ b/autodla/dbs/postgresdb.py
@@ -8,6 +8,9 @@ from datetime import date, datetime
 from typing import List, Optional
 from uuid import UUID
 import os
+import time
+import threading
+from .memorydb import MemoryDB
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 if "DATETIME_FORMAT" in os.environ:
@@ -114,22 +117,33 @@ class PostgresDataTransformer(DataTransformer):
         UUID: primary_key
     }
 
-class PostgresDB(DB_Connection):
+class PostgresDB(MemoryDB):
 
-    def __init__(self, connection_url=CONNECTION_URL):
-        self.__db_connection = psycopg2.connect(connection_url)
-        dt = PostgresDataTransformer()
-        super().__init__(dt, PostgresQueryBuilder(dt))
+    def __init__(self, connection_url=CONNECTION_URL, sync_interval: int = 5):
+        super().__init__()
+        self.__pg_connection = psycopg2.connect(connection_url)
+        self.__pg_dt = PostgresDataTransformer()
+        self.__pg_query = PostgresQueryBuilder(self.__pg_dt)
+        self.__last_snapshot = self._snapshot_tables()
+        self.__last_sync = time.time()
+        self.__sync_interval = sync_interval
+        self.__sync_thread = threading.Thread(target=self.__sync_loop, daemon=True)
+        self.__sync_thread.start()
     
     def get_table_definition(self, table_name) -> dict[str, type]:
         if "." in table_name:
             table_name = table_name.split(".")[-1]
-        res = self.execute(self.query.select(
+        qry = self.__pg_query.select(
             from_table='INFORMATION_SCHEMA.COLUMNS',
             columns=["column_name", "data_type"],
             limit=None,
             where=f"table_name = '{table_name}'"
-        )).to_dicts()
+        )
+        with self.__pg_connection.cursor() as cursor:
+            cursor.execute(qry)
+            res = cursor.fetchall()
+            schema_cols = [d[0] for d in cursor.description]
+            res = [dict(zip(schema_cols, r)) for r in res]
         conversion_dict = {
             "boolean": "bool",
             "timestamp without time zone": "timestamp"
@@ -142,26 +156,70 @@ class PostgresDB(DB_Connection):
         return out
                 
     def execute(self, statement, commit=True):
-        statement = self.normalize_statment(statement)
-        with self.__db_connection.cursor() as cursor:
-            if VERBOSE:
-                print()
-                print("$$$$$$ SQL STATEMENT $$$$$$")
-                print(statement)
-            cursor.execute(statement)
-            try:
+        if time.time() - self.__last_sync > self.__sync_interval:
+            self.synchronize()
+        return super().execute(statement, commit)
+
+    def _snapshot_tables(self) -> dict:
+        cursor = self._MemoryDB__db_connection.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = [r[0] for r in cursor.fetchall()]
+        snap = {}
+        for t in tables:
+            df = super().execute(f"SELECT * FROM {t}")
+            snap[t] = df if df is not None else pl.DataFrame()
+        return snap
+
+    def _compute_delta(self, old: dict, new: dict) -> dict:
+        delta = {}
+        for t, df_new in new.items():
+            df_old = old.get(t)
+            if df_old is None or len(df_old) == 0:
+                delta[t] = df_new
+            else:
+                diff = df_new.join(df_old, on=df_new.columns, how='anti')
+                delta[t] = diff
+        return delta
+
+    def _sync_to_postgres(self, delta: dict):
+        with self.__pg_connection.cursor() as cursor:
+            for table, df in delta.items():
+                if df is None or len(df) == 0:
+                    continue
+                values = df.to_dicts()
+                qry = self.__pg_query.insert(table, values).rstrip(';') + ' ON CONFLICT DO NOTHING;'
+                cursor.execute(qry)
+        self.__pg_connection.commit()
+
+    def _reload_memory(self):
+        with self.__pg_connection.cursor() as cursor:
+            m_cursor = self._MemoryDB__db_connection.cursor()
+            m_cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            tables = [r[0] for r in m_cursor.fetchall()]
+            for t in tables:
+                super().execute(f"DELETE FROM {t}")
+                cursor.execute(f"SELECT * FROM {t}")
                 rows = cursor.fetchall()
-                schema = [desc[0] for desc in cursor.description]
-                out = pl.DataFrame(rows, schema=schema, orient='row')
-                if VERBOSE:
-                    print()
-                    print(out)
-                return out
-            except:
-                return None
-            finally:
-                if commit:
-                    self.__db_connection.commit()
-                if VERBOSE:
-                    print("$$$$$$$$$$$$$")
-                    print()
+                if not rows:
+                    continue
+                columns = [d[0] for d in cursor.description]
+                values = [dict(zip(columns, r)) for r in rows]
+                qry = self.query.insert(t, values)
+                super().execute(qry)
+
+    def synchronize(self):
+        new_snap = self._snapshot_tables()
+        delta = self._compute_delta(self.__last_snapshot, new_snap)
+        self._sync_to_postgres(delta)
+        self._reload_memory()
+        self.__last_snapshot = self._snapshot_tables()
+        self.__last_sync = time.time()
+
+    def __sync_loop(self):
+        while True:
+            time.sleep(self.__sync_interval)
+            try:
+                self.synchronize()
+            except Exception:
+                pass
+

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -10,6 +10,8 @@ class User(Object):
     name: str
     age: int
 
+# MemoryDB stores everything in RAM. PostgresDB uses SQLite locally and
+# syncs changes to PostgreSQL.
 db = MemoryDB()  # or PostgresDB()
 db.attach([User])
 

--- a/docs/autodla_web.md
+++ b/docs/autodla_web.md
@@ -21,6 +21,8 @@ class Group(Object):
     group_name: str
     participants: list[User]
 
+# MemoryDB works only in-memory. PostgresDB keeps data in SQLite and
+# synchronizes with PostgreSQL.
 db = MemoryDB()  # or PostgresDB()
 db.attach([User, Group])
 ```

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -22,6 +22,8 @@ We need to instanciate the DataBase and then attach the Model into it.
 ```python
 from autodla.dbs import PostgresDB, MemoryDB
 
+# MemoryDB is purely in-memory. PostgresDB keeps a local SQLite store and
+# automatically syncs it to PostgreSQL.
 db = MemoryDB()  # or PostgresDB()
 db.attach([User])
 ```

--- a/examples/data_generation.py
+++ b/examples/data_generation.py
@@ -12,7 +12,8 @@ class User(Object):
     age: int
 
 
-# Connect to DB and register models
+# Connect to DB and register models. PostgresDB keeps a local SQLite store
+# and periodically syncs to the PostgreSQL server.
 db = PostgresDB()
 db.attach([User])
 

--- a/examples/fastapi-usage.py
+++ b/examples/fastapi-usage.py
@@ -20,7 +20,8 @@ class Group(Object):
     participants: list[User]
 
 
-# Connect to DB and register models
+# Connect to DB and register models. PostgresDB keeps a local SQLite store
+# and periodically syncs to the PostgreSQL server.
 db = PostgresDB()
 db.attach([User, Group])
 

--- a/examples/nested-objects-demo.py
+++ b/examples/nested-objects-demo.py
@@ -16,7 +16,8 @@ class Group(Object):
     group_name: str
 
 
-# Connect to DB and register models
+# Connect to DB and register models. PostgresDB keeps a local SQLite store
+# and periodically syncs to the PostgreSQL server.
 db = PostgresDB()
 db.attach([User, Group])
 

--- a/examples/simple_usage.py
+++ b/examples/simple_usage.py
@@ -11,7 +11,8 @@ class User(Object):
     age: int
 
 
-# Connect to DB and register models
+# Connect to DB and register models. PostgresDB keeps a local SQLite store
+# and periodically syncs to the PostgreSQL server.
 db = PostgresDB()
 db.attach([User])
 


### PR DESCRIPTION
## Summary
- make `PostgresDB` inherit from `MemoryDB`
- keep a Postgres connection and background synchronization thread
- sync local SQLite tables to Postgres and reload memory state
- update docs and examples to mention the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bfc07b9b0832b9432d2ae29465350